### PR TITLE
Permalinks & disable rolling "posts not found" message (after updating sculpin)

### DIFF
--- a/app/config/sculpin_kernel.yml
+++ b/app/config/sculpin_kernel.yml
@@ -2,10 +2,10 @@ sculpin:
     permalink: pretty
 sculpin_content_types:
     sponsors:
-      permalink: sponsors/:slug_title
+      permalink: sponsors/:slug_title/
     speakers:
-      permalink: speakers/:slug_title
+      permalink: speakers/:slug_title/
     talks:
-      permalink: talks/:slug_title
+      permalink: talks/:slug_title/
 sculpin_theme:
     theme: midwestphp/mwphp15-theme

--- a/app/config/sculpin_kernel.yml
+++ b/app/config/sculpin_kernel.yml
@@ -1,6 +1,8 @@
 sculpin:
     permalink: pretty
 sculpin_content_types:
+    posts:
+      enabled: false
     sponsors:
       permalink: sponsors/:slug_title/
     speakers:


### PR DESCRIPTION
After update sculpin.phar, these changes will fix the permalink generation and disable rolling "posts not found" message.

This should tidy up the urls to allow you to avoid the _ in the URL.